### PR TITLE
Blynk v.0.39.4 for Java 8 environment

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -18,7 +18,7 @@ VOLUME ["/config", "/data/backup"]
 
 # IP port listing: # 8443: Application mutual ssl/tls port # 8442: Hardware plain tcp/ip port # 8441: Hardware ssl/tls port (for hardware that supports SSL/TLS sockets) # 8081: Web socket ssl/tls port # 8082: Web sockets plain tcp/ip port # 9443: HTTPS port # 8080: HTTP port # 7443: Administration UI HTTPS port 
 
-EXPOSE 7443 8080 8081 8082 8441 8442 8443 9443 
+EXPOSE 8080 8440 8441 9443 
 WORKDIR /data
 
 ENTRYPOINT ["java", "-jar", "/blynk/server.jar", "-dataFolder", "/data", "-serverConfig", "/config/server.properties"]

--- a/dockerfile
+++ b/dockerfile
@@ -2,13 +2,13 @@ FROM hypriot/rpi-java
 
 MAINTAINER Mathias Renner <mathias@hypriot.com>
 
-ENV BLYNK_SERVER_VERSION 0.24.6 
+ENV BLYNK_SERVER_VERSION 0.39.4 
 
 RUN apt-get update \
 && apt-get install -y curl 
 
 RUN mkdir -p /blynk
-RUN curl -L https://github.com/blynkkk/blynk-server/releases/download/v${BLYNK_SERVER_VERSION}/server-${BLYNK_SERVER_VERSION}.jar > /blynk/server.jar
+RUN curl -L https://github.com/blynkkk/blynk-server/releases/download/v${BLYNK_SERVER_VERSION}/server-${BLYNK_SERVER_VERSION}-java8.jar > /blynk/server.jar
 # Create data folder. To persist data, map a volume to /data
 
 RUN mkdir -p /data


### PR DESCRIPTION
Uses v.0.39.4 of blynk
Works with latest Android app
Uses Java 8 based release for RPI (otherwise it is Java 10, which is not there for RPI)
Changed ports to match those in docs